### PR TITLE
Created ability to get merchant associated with an item, happy and sa…

### DIFF
--- a/app/controllers/api/v1/items_merchant_controller.rb
+++ b/app/controllers/api/v1/items_merchant_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::ItemsMerchantController < ApplicationController
+
+  def index
+    item = Item.find(params[:id])
+    render json: MerchantsSerializer.new(item.merchant)
+
+  rescue ActiveRecord::RecordNotFound
+    render json: {
+      errors: [
+        {
+          status: "404",
+          message: "Item not found"
+        }
+      ]
+    }, status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,5 @@ Rails.application.routes.draw do
   delete "/api/v1/items/:id", to: "api/v1/items#destroy"
 
   get "/api/v1/merchants/:id/items", to: "api/v1/merchant_items#index"
+  get "/api/v1/items/:id/merchant", to: "api/v1/items_merchant#index"
 end

--- a/spec/requests/api/v1/items_merchant_request_spec.rb
+++ b/spec/requests/api/v1/items_merchant_request_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "Items Merchant" do
+  describe "index" do
+
+    it "returns the merchant associated with an item" do
+      costco = Merchant.create!(name: "Costco")
+      item = Item.create!(name: "Golden Egg", description: "A beautiful egg that is solid gold", unit_price: 29.99, merchant_id: costco.id)
+    
+      get "/api/v1/items/#{item.id}/merchant"
+    
+      expect(response).to be_successful
+    
+      merchant = JSON.parse(response.body, symbolize_names: true)[:data]
+    
+      expect(merchant[:id]).to be_a(String)
+      expect(merchant[:type]).to eq("merchant")
+      expect(merchant[:attributes][:name]).to eq("Costco")
+    end
+    
+
+    it "has a sad path for when item is not found" do
+      costco = Merchant.create!(name: "Costco")
+      item = Item.create!(name: "Golden Egg", description: "A beautiful egg that is solid gold", unit_price: 29.99, merchant_id: costco.id)
+
+      get "/api/v1/items/#{item.id + 1}/merchant"
+
+      expect(response.status).to eq(404)
+
+      error_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(error_response).to have_key(:errors)
+      expect(error_response[:errors].first).to have_key(:status)
+      expect(error_response[:errors].first[:status]).to eq("404")
+
+      expect(error_response[:errors].first).to have_key(:message)
+      expect(error_response[:errors].first[:message]).to eq("Item not found")
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces the following changes:

Items Merchant Controller:

Added Api::V1::ItemsMerchantController with an index action that fetches the merchant associated with a specific item. If the item is found, the merchant is returned in the response. If the item is not found, a 404 error is returned with an appropriate error message.
Routes Update:

Added a new route GET /api/v1/items/:id/merchant to fetch the merchant associated with a specific item.
RSpec Tests:

Created request specs for the Items Merchant feature:
Happy path: Tests the successful retrieval of a merchant associated with an item.
Sad path: Tests the behavior when an item is not found, ensuring a 404 error and an appropriate error message are returned.
These updates improve the API by adding functionality to retrieve the merchant associated with an item and ensure proper error handling for non-existent items.